### PR TITLE
chore: remove type module from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@openmessage/qstream",
-  "type": "module",
   "version": "0.0.10",
   "description": "Topic-Based Messaging Queue on top of Redis Streams",
   "main": "lib",


### PR DESCRIPTION
Package type as "module" flags this package as a ES module.

before node 12 this generated a warning when trying to require() the package, but now it is throwing an error instead of a warning.

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module
